### PR TITLE
chore: drop support for Python 3.6 and format everything with Black

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pythonversion: ["3.6", "3.7", "3.8", "3.9"]
+        pythonversion: ["3.7", "3.8", "3.9"]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 venv
 *.egg-info
 .coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v0.5.0 (2021-09-20)
+
+* Drop support for Python 3.6
+* Swaps the `mock` library for the builting `unittest.mock` library
+* Formats project with `Black`
+
 ## v0.4.0 (2020-11-06)
 
 * Added a Sudoku solver and unit tests

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 ## lint - Lint the project
 lint:
 	venv/bin/flake8 algorithms/*.py
-	venv/bin/flake8 test/*.py
+	venv/bin/flake8 test/unit/*.py
 
 ## test - Test the project
 test:

--- a/algorithms/recursion/invert_binary_tree.py
+++ b/algorithms/recursion/invert_binary_tree.py
@@ -1,7 +1,6 @@
 class TreeNode:
     def __init__(self, x):
-        """Initialize a tree node object which accepts an integer.
-        """
+        """Initialize a tree node object which accepts an integer."""
         self.val = x
         self.left = None
         self.right = None
@@ -26,8 +25,7 @@ def invert_tree(node):
 
 
 def print_tree(node):
-    """Print the output of the tree.
-    """
+    """Print the output of the tree."""
     # Print the top level node
     print(node.val, end='')
 
@@ -39,8 +37,7 @@ def print_tree(node):
 
 
 def main():
-    """Runs the program.
-    """
+    """Runs the program."""
     tree = TreeNode(1)
     tree.left = TreeNode(2)
     tree.right = TreeNode(3)

--- a/algorithms/recursion/sudoku.py
+++ b/algorithms/recursion/sudoku.py
@@ -1,6 +1,6 @@
 import sys
-import numpy as np
 
+import numpy as np
 
 """
 SUDOKU
@@ -20,11 +20,10 @@ at the right place so you don't have an eternal loop and your recursion can move
 """
 
 
-class Sudoku():
+class Sudoku:
     @classmethod
     def run(cls):
-        """Run the Sudoku puzzle solver
-        """
+        """Run the Sudoku puzzle solver"""
         global count_numbers_added
         global count_numbers_backtracked
         count_numbers_added = 0
@@ -38,7 +37,7 @@ class Sudoku():
             [0, 5, 0, 0, 9, 0, 6, 0, 0],
             [1, 3, 0, 0, 0, 0, 2, 5, 0],
             [0, 0, 0, 0, 0, 0, 0, 7, 4],
-            [0, 0, 5, 2, 0, 6, 3, 0, 0]
+            [0, 0, 5, 2, 0, 6, 3, 0, 0],
         ]
         # TODO: Allow for dynamic grid generation
         # grid = cls.generate_numpy_grid()
@@ -63,8 +62,7 @@ class Sudoku():
 
     @classmethod
     def generate_numpy_grid(cls):
-        """Generate a numpy grid of dynamic numbers
-        """
+        """Generate a numpy grid of dynamic numbers"""
         # TODO: Fix this generation, currently it works great to
         # generate a grid; however, it does not generate a correct
         # Sudoku grid that starts with only one number per row,
@@ -78,6 +76,7 @@ class Sudoku():
         grid = numpy_array
         for row in grid:
             print(row)
+
         return grid
 
     @classmethod
@@ -96,8 +95,8 @@ class Sudoku():
 
         # Check the 3x3 block for a number that
         # is already inside the 3x3 block
-        x_block = (x//3)*3
-        y_block = (y//3)*3
+        x_block = (x // 3) * 3
+        y_block = (y // 3) * 3
         for i in range(3):
             for j in range(3):
                 if grid[y_block + i][x_block + j] == n:
@@ -127,6 +126,7 @@ class Sudoku():
                             grid[y][x] = 0
                             count_numbers_backtracked += 1
                     return False
+
         return grid
 
 

--- a/algorithms/sequences/fibonnaci_sequence.py
+++ b/algorithms/sequences/fibonnaci_sequence.py
@@ -1,6 +1,5 @@
-import sys
 import os
-
+import sys
 
 """
 FIBONACCI SEQUENCE
@@ -15,29 +14,30 @@ Usage: ITERATIONS=20 venv/bin/python fibonnaci_sequence.py
 ITERATIONS = int(os.getenv('ITERATIONS', 15))
 
 
-class FibonacciSequence():
+class FibonacciSequence:
     @classmethod
     def run(cls):
         cls.validate_iterations()
         print(f'The Fibonacci Sequence to {ITERATIONS} iterations:')
         fibonacci_sequence = cls.iterate_fibonacci_sequence()
+
         return fibonacci_sequence
 
     @classmethod
     def validate_iterations(cls):
-        """Check if the first parameter exceeds the max iterations allowed
-        """
+        """Check if the first parameter exceeds the max iterations allowed"""
         if ITERATIONS >= 94:
-            sys.exit(('This tool can only print up to 93 iterations before the'
-                      ' Fibonacci number exceeds the max value allowed.'
-                      ' Please select a lower number and try again.'))
+            sys.exit(
+                'This tool can only print up to 93 iterations before the'
+                ' Fibonacci number exceeds the max value allowed.'
+                ' Please select a lower number and try again.'
+            )
         if ITERATIONS < 1:
             sys.exit('ITERATIONS must be greater than or equal to 1.')
 
     @classmethod
     def iterate_fibonacci_sequence(cls):
-        """Iterate through the Fibonacci Sequence to the desired iteration
-        """
+        """Iterate through the Fibonacci Sequence to the desired iteration"""
         new_number = 0
         this_number = 1
         previous_number = 0
@@ -50,6 +50,7 @@ class FibonacciSequence():
             final_list.append(new_number)
             counter += 1
         print(final_list)
+
         return final_list
 
 

--- a/algorithms/sequences/fizzbuzz.py
+++ b/algorithms/sequences/fizzbuzz.py
@@ -20,7 +20,7 @@ Fizz or Buzz
 ITERATIONS = int(os.getenv('ITERATIONS', 15))
 
 
-class FizzBuzz():
+class FizzBuzz:
     @classmethod
     def run(cls):
         """Iterate through numbers and
@@ -36,8 +36,7 @@ class FizzBuzz():
 
     @classmethod
     def validate_iterations(cls):
-        """Validate the iterations before proceeding
-        """
+        """Validate the iterations before proceeding"""
         if ITERATIONS < 1:
             sys.exit('ITERATIONS must be greater than or equal to 1.')
 
@@ -46,8 +45,8 @@ class FizzBuzz():
         """Determine what the output of each iteration
         is based on its divisibility.
         """
-        fizz = (i % 3 == 0)
-        buzz = (i % 5 == 0)
+        fizz = i % 3 == 0
+        buzz = i % 5 == 0
         if fizz and buzz:
             output = 'FizzBuzz'
         elif fizz:
@@ -56,6 +55,7 @@ class FizzBuzz():
             output = 'Buzz'
         else:
             output = i
+
         return output
 
 

--- a/algorithms/sorting/bubble_sort.py
+++ b/algorithms/sorting/bubble_sort.py
@@ -27,10 +27,9 @@ number is bigger so it thinks it's done.
 LIST = [3, 1, 5, 9, 7, 6, 2, 8, 4]
 
 
-class BubbleSort():
+class BubbleSort:
     def sort():
-        """Bubble sort a list
-        """
+        """Bubble sort a list"""
         previous_index = 0
         next_index = 1
         new_array = LIST
@@ -41,11 +40,9 @@ class BubbleSort():
         start_time = datetime.now()
         while num_times_skipped + 1 != len(LIST):
             try:
-                if (LIST[next_index] < LIST[previous_index]
-                        and LIST[next_index] != LIST[previous_index]):
+                if LIST[next_index] < LIST[previous_index] and LIST[next_index] != LIST[previous_index]:
                     new_array.insert(next_index, new_array.pop(previous_index))
-                    print(
-                        f'{new_array} => Swapped {LIST[next_index]} and {LIST[previous_index]}')
+                    print(f'{new_array} => Swapped {LIST[next_index]} and {LIST[previous_index]}')
                     previous_index += 1
                     next_index += 1
                 else:
@@ -59,6 +56,7 @@ class BubbleSort():
                 i += 1
         end_time = datetime.now() - start_time
         print(f'List sorted successfully in {end_time} with Bubble Sort Algorithm!')
+
         return new_array
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-
 import setuptools
 
 with open('README.md', 'r') as fh:
@@ -11,14 +10,13 @@ REQUIREMENTS = [
 DEV_REQUIREMENTS = [
     'coveralls == 3.*',
     'flake8',
-    'mock == 4.*',
     'pytest == 6.*',
     'pytest-cov == 2.*',
 ]
 
 setuptools.setup(
     name='algorithms',
-    version='0.4.0',
+    version='0.5.0',
     description='A repo of algorithms.',
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -33,7 +31,7 @@ setuptools.setup(
     ],
     install_requires=REQUIREMENTS,
     extras_require={
-        'dev': DEV_REQUIREMENTS
+        'dev': DEV_REQUIREMENTS,
     },
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )

--- a/test/unit/recursion/test_invert_binary_tree.py
+++ b/test/unit/recursion/test_invert_binary_tree.py
@@ -3,6 +3,7 @@ from algorithms.recursion.invert_binary_tree import main
 
 def test_run_invert_tree():
     tree = main()
+
     assert tree.val == 1
     assert tree.left.val == 3
     assert tree.left.right.val == 6

--- a/test/unit/recursion/test_sudoku.py
+++ b/test/unit/recursion/test_sudoku.py
@@ -1,6 +1,6 @@
-import mock
-from algorithms import Sudoku
+from unittest.mock import patch
 
+from algorithms import Sudoku
 
 GRID = [
     [3, 0, 6, 5, 0, 8, 4, 0, 0],
@@ -11,25 +11,28 @@ GRID = [
     [0, 5, 0, 0, 9, 0, 6, 0, 0],
     [1, 3, 0, 0, 0, 0, 2, 5, 0],
     [0, 0, 0, 0, 0, 0, 0, 7, 4],
-    [0, 0, 5, 2, 0, 6, 3, 0, 0]
+    [0, 0, 5, 2, 0, 6, 3, 0, 0],
 ]
 
 
-@mock.patch('algorithms.recursion.sudoku.Sudoku.solve_puzzle')
+@patch('algorithms.recursion.sudoku.Sudoku.solve_puzzle')
 def test_run(mock_solve_puzzle):
     Sudoku.run()
+
     mock_solve_puzzle.assert_called_once()
 
 
-@mock.patch('sys.exit')
-@mock.patch('algorithms.recursion.sudoku.Sudoku.solve_puzzle', return_value=False)
+@patch('sys.exit')
+@patch('algorithms.recursion.sudoku.Sudoku.solve_puzzle', return_value=False)
 def test_run_no_solution(mock_solve_puzzle, mock_sys_exit):
     Sudoku.run()
+
     mock_sys_exit.assert_called_once_with('No solution!')
 
 
 def test_generate_numpy_grid():
     grid = Sudoku.generate_numpy_grid()
+
     for i, row in enumerate(grid):
         assert len(row) == 9
         assert len(grid[i]) == 9
@@ -39,17 +42,28 @@ def test_check_valid_number():
     check_false_row = Sudoku.check_valid_number(0, 1, 3, GRID)
     check_true_all = Sudoku.check_valid_number(8, 8, 8, GRID)
     check_false_block = Sudoku.check_valid_number(8, 8, 7, GRID)
+
     assert check_false_row is False
     assert check_true_all is True
     assert check_false_block is False
 
 
-@mock.patch('algorithms.recursion.sudoku.Sudoku.check_valid_number')
+@patch('algorithms.recursion.sudoku.Sudoku.check_valid_number')
 def test_solve_puzzle(check_valid_number):
     solved_grid = Sudoku.solve_puzzle(GRID)
     check_valid_number.assert_called()
-    assert solved_grid == [[3, 1, 6, 5, 1, 8, 4, 1, 1], [5, 2, 1, 1, 1, 1, 1, 1, 1], [1, 8, 7, 1, 1, 1, 1, 3, 1], [1, 1, 3, 1, 1, 1, 1, 8, 1], [  # noqa
-        9, 1, 1, 8, 6, 3, 1, 1, 5], [1, 5, 1, 1, 9, 1, 6, 1, 1], [1, 3, 1, 1, 1, 1, 2, 5, 1], [1, 1, 1, 1, 1, 1, 1, 7, 4], [1, 1, 5, 2, 1, 6, 3, 1, 1]]  # noqa
+
+    assert solved_grid == [
+        [3, 1, 6, 5, 1, 8, 4, 1, 1],
+        [5, 2, 1, 1, 1, 1, 1, 1, 1],
+        [1, 8, 7, 1, 1, 1, 1, 3, 1],
+        [1, 1, 3, 1, 1, 1, 1, 8, 1],
+        [9, 1, 1, 8, 6, 3, 1, 1, 5],
+        [1, 5, 1, 1, 9, 1, 6, 1, 1],
+        [1, 3, 1, 1, 1, 1, 2, 5, 1],
+        [1, 1, 1, 1, 1, 1, 1, 7, 4],
+        [1, 1, 5, 2, 1, 6, 3, 1, 1],
+    ]
 
 
 # TODO: Test branches of solve_puzzle, this will require dynamically loading a grid most likely

--- a/test/unit/sequences/test_fibonnaci_sequence.py
+++ b/test/unit/sequences/test_fibonnaci_sequence.py
@@ -1,21 +1,25 @@
-import mock
+from unittest.mock import patch
+
 from algorithms import FibonacciSequence
 
 
 def test_fibonacci_sequence():
     fibonacci_sequence = FibonacciSequence.run()
+
     assert fibonacci_sequence == [1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377]
 
 
-@mock.patch('algorithms.sequences.fibonnaci_sequence.ITERATIONS', 94)
-@mock.patch('sys.exit')
+@patch('algorithms.sequences.fibonnaci_sequence.ITERATIONS', 94)
+@patch('sys.exit')
 def test_fibonacci_sequence_iteration_too_large(mock_sys_exit):
     FibonacciSequence.run()
+
     mock_sys_exit.assert_called_once()
 
 
-@mock.patch('algorithms.sequences.fibonnaci_sequence.ITERATIONS', -1)
-@mock.patch('sys.exit')
+@patch('algorithms.sequences.fibonnaci_sequence.ITERATIONS', -1)
+@patch('sys.exit')
 def test_fibonacci_sequence_iteration_less_than_1(mock_sys_exit):
     FibonacciSequence.run()
+
     mock_sys_exit.assert_called_once()

--- a/test/unit/sequences/test_fizzbuzz.py
+++ b/test/unit/sequences/test_fizzbuzz.py
@@ -1,35 +1,42 @@
-import mock
+from unittest.mock import patch
+
 from algorithms import FizzBuzz
 
 
-@mock.patch('algorithms.sequences.fizzbuzz.FizzBuzz.determine_output')
+@patch('algorithms.sequences.fizzbuzz.FizzBuzz.determine_output')
 def test_fizzbuzz_run(mock_determine_output):
     FizzBuzz.run()
+
     assert mock_determine_output.call_count == 15
 
 
 def test_fizzbuzz_determine_output_fizz():
     output = FizzBuzz.determine_output(3)
+
     assert output == 'Fizz'
 
 
 def test_fizzbuzz_determine_output_buzz():
     output = FizzBuzz.determine_output(5)
+
     assert output == 'Buzz'
 
 
 def test_fizzbuzz_determine_output_fizzbuzz():
     output = FizzBuzz.determine_output(15)
+
     assert output == 'FizzBuzz'
 
 
 def test_fizzbuzz_determine_output_normal():
     output = FizzBuzz.determine_output(1)
+
     assert output == 1
 
 
-@mock.patch('algorithms.sequences.fizzbuzz.ITERATIONS', -1)
-@mock.patch('sys.exit')
+@patch('algorithms.sequences.fizzbuzz.ITERATIONS', -1)
+@patch('sys.exit')
 def test_fibonacci_sequence_iteration_less_than_1(mock_sys_exit):
     FizzBuzz.run()
+
     mock_sys_exit.assert_called_once()

--- a/test/unit/sorting/test_bubble_sort.py
+++ b/test/unit/sorting/test_bubble_sort.py
@@ -3,4 +3,5 @@ from algorithms import BubbleSort
 
 def test_bubble_sort():
     bubble_sort = BubbleSort.sort()
+
     assert bubble_sort == [1, 2, 3, 4, 5, 6, 7, 8, 9]


### PR DESCRIPTION
* Drop support for Python 3.6
* Swaps the `mock` library for the builting `unittest.mock` library
* Formats project with `Black`